### PR TITLE
feat: functions to get a ConfigurationV2 with consent or preference info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "tslib": "^2.5.0"
       },
       "devDependencies": {
-        "@ketch-sdk/ketch-types": "^1.17.1",
+        "@ketch-sdk/ketch-types": "^1.20.0",
         "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
@@ -1238,9 +1238,9 @@
       }
     },
     "node_modules/@ketch-sdk/ketch-types": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.17.1.tgz",
-      "integrity": "sha512-MOjBk3+0LJoeJrF1fgSgv1Ko5uEsp7nskwJa+8C76Pow/aQk8xmu0tmoPD4KZpMxyzzmt6ZC687cRQU8aOCeqg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.20.0.tgz",
+      "integrity": "sha512-ztTeVxAnaQIl2mUbn2PtO+z49dFjjMmGNbjuUu5jES8WREudikUkef1lCt0gFneylANl//X4hh29Ax/56vSA3g==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7503,9 +7503,9 @@
       }
     },
     "@ketch-sdk/ketch-types": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.17.1.tgz",
-      "integrity": "sha512-MOjBk3+0LJoeJrF1fgSgv1Ko5uEsp7nskwJa+8C76Pow/aQk8xmu0tmoPD4KZpMxyzzmt6ZC687cRQU8aOCeqg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@ketch-sdk/ketch-types/-/ketch-types-1.20.0.tgz",
+      "integrity": "sha512-ztTeVxAnaQIl2mUbn2PtO+z49dFjjMmGNbjuUu5jES8WREudikUkef1lCt0gFneylANl//X4hh29Ax/56vSA3g==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/ketch-sdk/ketch-web-api/issues"
   },
   "devDependencies": {
-    "@ketch-sdk/ketch-types": "^1.17.1",
+    "@ketch-sdk/ketch-types": "^1.20.0",
     "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -123,7 +123,7 @@ describe('@ketch-com/ketch-web-api', () => {
     })
   })
 
-  describe('GetConsentConfigurationV2', () => {
+  describe('GetConsentConfigurationV2 - With hash', () => {
     it('calls service', () => {
       const v: ConfigurationV2 = {
         organization: {
@@ -150,7 +150,33 @@ describe('@ketch-com/ketch-web-api', () => {
     })
   })
 
-  describe('GetPreferenceConfigurationV2', () => {
+  describe('GetConsentConfigurationV2 - Without hash', () => {
+    it('calls service', () => {
+      const v: ConfigurationV2 = {
+        organization: {
+          code: 'switchbitcorp',
+        },
+        formTemplates: [],
+      }
+      mockFetch.mockResponseOnce(JSON.stringify(v))
+
+      expect(
+        api.getConsentConfigurationV2({
+          propertyCode: 'foo',
+          envCode: 'test',
+          jurisdictionCode: 'bar',
+          langCode: 'en-US',
+        }),
+      ).resolves.toStrictEqual(v)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://global.ketchcdn.com/web/v2/foo/test/bar/en-US/consent.json',
+        getOptions,
+      )
+    })
+  })
+
+  describe('GetPreferenceConfigurationV2 - With hash', () => {
     it('calls service', () => {
       const v: ConfigurationV2 = {
         organization: {
@@ -172,6 +198,32 @@ describe('@ketch-com/ketch-web-api', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://global.ketchcdn.com/web/v2/foo/test/bar/en-US/preference.json?hash=baz',
+        getOptions,
+      )
+    })
+  })
+
+  describe('GetPreferenceConfigurationV2 - Without hash', () => {
+    it('calls service', () => {
+      const v: ConfigurationV2 = {
+        organization: {
+          code: 'switchbitcorp',
+        },
+        formTemplates: [],
+      }
+      mockFetch.mockResponseOnce(JSON.stringify(v))
+
+      expect(
+        api.getPreferenceConfigurationV2({
+          propertyCode: 'foo',
+          envCode: 'test',
+          jurisdictionCode: 'bar',
+          langCode: 'en-US',
+        }),
+      ).resolves.toStrictEqual(v)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://global.ketchcdn.com/web/v2/foo/test/bar/en-US/preference.json',
         getOptions,
       )
     })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable jest/valid-expect */
+import { ConfigurationV2 } from '@ketch-sdk/ketch-types'
 import { KetchWebAPI } from './index'
 import mockFetch from 'jest-fetch-mock'
 
@@ -117,6 +118,60 @@ describe('@ketch-com/ketch-web-api', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://global.ketchcdn.com/web/v2/config/switchbitcorp/foo/en-US/bar/subscriptions.json',
+        getOptions,
+      )
+    })
+  })
+
+  describe('GetConsentConfigurationV2', () => {
+    it('calls service', () => {
+      const v: ConfigurationV2 = {
+        organization: {
+          code: 'switchbitcorp',
+        },
+        formTemplates: [],
+      }
+      mockFetch.mockResponseOnce(JSON.stringify(v))
+
+      expect(
+        api.getConsentConfigurationV2({
+          propertyCode: 'foo',
+          envCode: 'test',
+          jurisdictionCode: 'bar',
+          langCode: 'en-US',
+          hash: 'baz',
+        }),
+      ).resolves.toStrictEqual(v)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://global.ketchcdn.com/web/v2/foo/test/bar/en-US/consent.json?hash=baz',
+        getOptions,
+      )
+    })
+  })
+
+  describe('GetPreferenceConfigurationV2', () => {
+    it('calls service', () => {
+      const v: ConfigurationV2 = {
+        organization: {
+          code: 'switchbitcorp',
+        },
+        formTemplates: [],
+      }
+      mockFetch.mockResponseOnce(JSON.stringify(v))
+
+      expect(
+        api.getPreferenceConfigurationV2({
+          propertyCode: 'foo',
+          envCode: 'test',
+          jurisdictionCode: 'bar',
+          langCode: 'en-US',
+          hash: 'baz',
+        }),
+      ).resolves.toStrictEqual(v)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://global.ketchcdn.com/web/v2/foo/test/bar/en-US/preference.json?hash=baz',
         getOptions,
       )
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export class KetchWebAPI {
     hash,
   }: GetConsentConfigurationV2Request): Promise<ConfigurationV2> {
     const resp = await this.get(
-      `/${propertyCode}/${envCode}/${jurisdictionCode}/${langCode}/consent.json${!!hash ? `?hash=${hash}` : ''}`,
+      `/${propertyCode}/${envCode}/${jurisdictionCode}/${langCode}/consent.json${hash ? `?hash=${hash}` : ''}`,
     )
     return resp as ConfigurationV2
   }
@@ -122,7 +122,7 @@ export class KetchWebAPI {
     hash,
   }: GetPreferenceConfigurationV2Request): Promise<ConfigurationV2> {
     const resp = await this.get(
-      `/${propertyCode}/${envCode}/${jurisdictionCode}/${langCode}/preference.json${!!hash ? `?hash=${hash}` : ''}`,
+      `/${propertyCode}/${envCode}/${jurisdictionCode}/${langCode}/preference.json${hash ? `?hash=${hash}` : ''}`,
     )
     return resp as ConfigurationV2
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ import {
   InvokeRightRequest,
   SetConsentRequest,
   WebReportRequest,
+  ConfigurationV2,
+  GetConsentConfigurationV2Request,
+  GetPreferenceConfigurationV2Request,
 } from '@ketch-sdk/ketch-types'
 
 /**
@@ -86,6 +89,42 @@ export class KetchWebAPI {
     } = request
     const resp = await this.get(`/config/${orgCode}/${propCode}/${langCode}/${expCode}/subscriptions.json`)
     return resp as SubscriptionConfiguration
+  }
+
+  /**
+   * Gets a v2 configuration, containing only consent experience information, for the specified parameters.
+   *
+   * @param request The configuration request
+   */
+  async getConsentConfigurationV2({
+    propertyCode,
+    envCode,
+    jurisdictionCode,
+    langCode,
+    hash,
+  }: GetConsentConfigurationV2Request): Promise<ConfigurationV2> {
+    const resp = await this.get(
+      `/${propertyCode}/${envCode}/${jurisdictionCode}/${langCode}/consent.json${!!hash ? `?hash=${hash}` : ''}`,
+    )
+    return resp as ConfigurationV2
+  }
+
+  /**
+   * Gets a v2 configuration, containing only preference experience information, for the specified parameters.
+   *
+   * @param request The configuration request
+   */
+  async getPreferenceConfigurationV2({
+    propertyCode,
+    envCode,
+    jurisdictionCode,
+    langCode,
+    hash,
+  }: GetPreferenceConfigurationV2Request): Promise<ConfigurationV2> {
+    const resp = await this.get(
+      `/${propertyCode}/${envCode}/${jurisdictionCode}/${langCode}/preference.json${!!hash ? `?hash=${hash}` : ''}`,
+    )
+    return resp as ConfigurationV2
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Two functions that both fetch a ConfigurationV2 object, one with consent experience config info and one with preference experience config info

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
